### PR TITLE
bugfix attempt for https://github.com/wq/django-natural-keys/issues/8

### DIFF
--- a/natural_keys/models.py
+++ b/natural_keys/models.py
@@ -5,7 +5,7 @@ from functools import reduce
 class NaturalKeyQuerySet(models.QuerySet):
     def filter(self, *args, **kwargs):
         natural_key_slug = kwargs.pop('natural_key_slug', None)
-        if natural_key_slug:
+        if natural_key_slug and type(natural_key_slug) is str:
             slugs = natural_key_slug.split(
                 self.model.natural_key_separator
             )


### PR DESCRIPTION
This should fix #8 by running the function only when its argument is a string (and thus a natural key slug)